### PR TITLE
Feature/extend configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,6 @@ node_js:
   - 'iojs'
   - '0.12'
   - '0.10'
+before_install:
+  - npm install -g npm@latest
+  - npm install --save-dev stylint

--- a/test/config/.stylintrc_error
+++ b/test/config/.stylintrc_error
@@ -1,0 +1,6 @@
+{
+    "semicolons": {
+        "expect": "never",
+        "error": true
+    }
+}

--- a/test/config/.stylintrc_ok
+++ b/test/config/.stylintrc_ok
@@ -1,0 +1,7 @@
+{
+    "semicolons": {
+        "expect": "never",
+        "error": true
+    },
+    "colons": "never"
+}

--- a/test/config/.stylintrc_warning
+++ b/test/config/.stylintrc_warning
@@ -1,0 +1,3 @@
+{
+    "semicolons": "never"
+}

--- a/test/error.js
+++ b/test/error.js
@@ -6,14 +6,32 @@ var assign = require('object-assign');
 var globalConf = require('./utils/conf');
 
 describe('stylint loader', function() {
-  it('should return error if file contains stylint error', function(done) {
+  it('should return error if file contains stylint error based on given .stylintrc', function(done) {
     var localConfig = {
       entry: './test/fixtures/error.js',
       stylint: {
-        semicolons: {
-          expect: 'never',
-          error: true
-        }
+        config: './test/config/.stylintrc_error'
+      }
+    };
+
+    webpack(assign({}, globalConf, localConfig), function(err, stats) {
+      assert.equal(err, null);
+      assert.equal(stats.hasErrors(), true);
+      done();
+    });
+  });
+
+  it('should return error if file contains stylint error based on passed url params', function(done) {
+    var localConfig = {
+      entry: './test/fixtures/error.js',
+      module: {
+        preLoaders: [
+          {
+            test: /\.styl$/,
+            loader: '../../index?{ semicolons: { expect: "never", error: true} }',
+            exclude: /node_modules/
+          }
+        ]
       }
     };
 

--- a/test/ok.js
+++ b/test/ok.js
@@ -6,15 +6,11 @@ var assign = require('object-assign');
 var globalConf = require('./utils/conf');
 
 describe('stylint loader', function() {
-  it('shouldn\'t return error or warning if file it\'s ok', function(done) {
+  it('shouldn\'t return error or warning if file it\'s ok based on given .stylintrc', function(done) {
     var localConfig = {
       entry: './test/fixtures/ok.js',
       stylint: {
-        semicolons: {
-          expect: 'never',
-          error: true
-        },
-        colons: 'never'
+        config: './test/config/.stylintrc_ok'
       }
     };
 

--- a/test/warning.js
+++ b/test/warning.js
@@ -6,11 +6,32 @@ var assign = require('object-assign');
 var globalConf = require('./utils/conf');
 
 describe('stylint loader', function() {
-  it('should return warning if file contains stylint warning', function(done) {
+  it('should return warning if file contains stylint warning based on given .stylintrc', function(done) {
     var localConfig = {
       entry: './test/fixtures/warning.js',
       stylint: {
-        semicolons: 'never'
+        config: './test/config/.stylintrc_warning'
+      }
+    };
+
+    webpack(assign({}, globalConf, localConfig), function(err, stats) {
+      assert.equal(err, null);
+      assert.equal(stats.hasWarnings(), true);
+      done();
+    });
+  });
+
+  it('should return warning if file contains stylint warning based on passed url params', function(done) {
+    var localConfig = {
+      entry: './test/fixtures/warning.js',
+      module: {
+        preLoaders: [
+          {
+            test: /\.styl$/,
+            loader: '../../index?{ semicolons: "never" }',
+            exclude: /node_modules/
+          }
+        ]
       }
     };
 


### PR DESCRIPTION
This PR extends a bit the abilities of `stylint-loader` and makes it's configuration more similar to the original [stylint](https://github.com/rossPatton/stylint). With it validation rules could be passed in 2 ways (actually as described in Readme file):
1. via URL params:

```
preLoaders: [
          {
            test: /\.styl$/,
            loader: '../../index?{ semicolons: { expect: "never", error: true} }',
            exclude: /node_modules/
          }
        ]
```
1. as a config file:

```
stylint: {
        config: './test/config/.stylintrc'
      }
```
